### PR TITLE
Add Kubernetes CLI (kubectl) Ansible Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # iac-tool
-Install tools build and push to docker hib
+Automation tools for Infrastructure as Code (IaC) workflows
+
+## Available Tools
+
+### Kubernetes CLI (kubectl)
+
+An Ansible role for installing the Kubernetes command-line tool (kubectl) on target systems.
+
+**Usage:**
+
+```bash
+# Install kubectl with default settings (latest stable version)
+ansible-playbook playbooks/install_kubernetes_cli.yml
+
+# Use the role in your own playbook
+- hosts: servers
+  roles:
+    - role: kubernetes_cli
+      kubectl_version: "v1.28.0"  # Optional: specify version
+```
+
+See [role documentation](roles/kubernetes_cli/README.md) for more details and configuration options.

--- a/playbooks/install_kubernetes_cli.yml
+++ b/playbooks/install_kubernetes_cli.yml
@@ -1,0 +1,8 @@
+---
+- name: Install Kubernetes CLI
+  hosts: all
+  become: true
+  roles:
+    - role: kubernetes_cli
+      # Uncomment and update to install a specific version
+      # kubectl_version: "v1.28.0"

--- a/roles/kubernetes_cli/README.md
+++ b/roles/kubernetes_cli/README.md
@@ -1,0 +1,43 @@
+# Kubernetes CLI (kubectl) Installation Role
+
+This Ansible role installs the Kubernetes command-line tool, kubectl, on target systems.
+
+## Requirements
+
+- Ansible 2.9 or higher
+- Target systems with internet access for downloading kubectl binary
+
+## Role Variables
+
+```yaml
+# kubectl version to install (defaults to latest stable)
+kubectl_version: "stable"
+
+# Installation directory
+kubectl_install_dir: "/usr/local/bin"
+
+# Owner and mode for the kubectl binary
+kubectl_owner: "root"
+kubectl_group: "root"
+kubectl_mode: "0755"
+
+# Whether to verify the kubectl binary's GPG signature
+kubectl_verify_signature: true
+```
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - role: kubernetes_cli
+      kubectl_version: "v1.28.0"
+```
+
+## License
+
+MIT

--- a/roles/kubernetes_cli/defaults/main.yml
+++ b/roles/kubernetes_cli/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+# defaults file for kubernetes_cli
+
+# kubectl version to install (defaults to latest stable)
+kubectl_version: "stable"
+
+# Installation directory
+kubectl_install_dir: "/usr/local/bin"
+
+# Owner and mode for the kubectl binary
+kubectl_owner: "root"
+kubectl_group: "root"
+kubectl_mode: "0755"
+
+# Whether to verify the kubectl binary's GPG signature
+kubectl_verify_signature: true
+
+# Temp directory for downloads
+kubectl_temp_dir: "/tmp/kubectl_install"
+
+# OS specific settings
+kubectl_os_map:
+  Linux: "linux"
+  Darwin: "darwin"
+
+# Architecture specific settings
+kubectl_arch_map:
+  x86_64: "amd64"
+  amd64: "amd64"
+  arm64: "arm64"
+  aarch64: "arm64"
+  armv7l: "arm"
+  armv6l: "arm"
+  ppc64le: "ppc64le"
+  s390x: "s390x"

--- a/roles/kubernetes_cli/handlers/main.yml
+++ b/roles/kubernetes_cli/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for kubernetes_cli

--- a/roles/kubernetes_cli/meta/main.yml
+++ b/roles/kubernetes_cli/meta/main.yml
@@ -1,0 +1,35 @@
+---
+galaxy_info:
+  role_name: kubernetes_cli
+  author: IaC Tool Maintainers
+  description: Installs Kubernetes CLI (kubectl)
+  license: MIT
+  min_ansible_version: 2.9
+  platforms:
+    - name: EL
+      versions:
+        - 7
+        - 8
+        - 9
+    - name: Fedora
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+        - bookworm
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - mantic
+  galaxy_tags:
+    - kubernetes
+    - kubectl
+    - k8s
+    - cli
+    - system
+    - tools
+
+dependencies: []

--- a/roles/kubernetes_cli/tasks/main.yml
+++ b/roles/kubernetes_cli/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+# tasks file for kubernetes_cli
+
+- name: Ensure temp directory exists
+  file:
+    path: "{{ kubectl_temp_dir }}"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Determine OS and architecture
+  set_fact:
+    kubectl_os: "{{ kubectl_os_map[ansible_system] | default('linux') }}"
+    kubectl_arch: "{{ kubectl_arch_map[ansible_architecture] | default('amd64') }}"
+
+- name: Get latest stable kubectl version if requested
+  block:
+    - name: Get latest kubectl version
+      uri:
+        url: https://dl.k8s.io/release/stable.txt
+        return_content: yes
+      register: kubectl_stable_version
+      when: kubectl_version == "stable"
+
+    - name: Set kubectl version to latest stable
+      set_fact:
+        kubectl_version: "{{ kubectl_stable_version.content | trim }}"
+      when: kubectl_version == "stable"
+  when: kubectl_version == "stable"
+
+- name: Download kubectl binary
+  get_url:
+    url: "https://dl.k8s.io/release/{{ kubectl_version }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl"
+    dest: "{{ kubectl_temp_dir }}/kubectl"
+    mode: '0755'
+  become: true
+
+- name: Download kubectl checksum file
+  get_url:
+    url: "https://dl.k8s.io/release/{{ kubectl_version }}/bin/{{ kubectl_os }}/{{ kubectl_arch }}/kubectl.sha256"
+    dest: "{{ kubectl_temp_dir }}/kubectl.sha256"
+  become: true
+  when: kubectl_verify_signature
+
+- name: Verify kubectl binary
+  shell: |
+    echo "$(cat {{ kubectl_temp_dir }}/kubectl.sha256)  {{ kubectl_temp_dir }}/kubectl" | sha256sum --check
+  register: kubectl_verify_result
+  changed_when: false
+  failed_when: kubectl_verify_result.rc != 0
+  become: true
+  when: kubectl_verify_signature
+
+- name: Install kubectl binary
+  copy:
+    src: "{{ kubectl_temp_dir }}/kubectl"
+    remote_src: yes
+    dest: "{{ kubectl_install_dir }}/kubectl"
+    owner: "{{ kubectl_owner }}"
+    group: "{{ kubectl_group }}"
+    mode: "{{ kubectl_mode }}"
+  become: true
+
+- name: Verify kubectl installation
+  command: "{{ kubectl_install_dir }}/kubectl version --client"
+  register: kubectl_version_result
+  changed_when: false
+
+- name: Clean up temp directory
+  file:
+    path: "{{ kubectl_temp_dir }}"
+    state: absent
+  become: true


### PR DESCRIPTION
## Description

This pull request adds an Ansible role for installing the Kubernetes CLI (kubectl) on target systems. The role provides a standardized way to install and configure kubectl across different environments.

### Features

- Installs kubectl from official Kubernetes sources
- Supports specific versions or latest stable release
- Verifies downloaded binary with SHA256 checksum
- Works across different operating systems and CPU architectures
- Well-documented with configuration options

### Usage

To use this role, run the included playbook:
```bash
ansible-playbook playbooks/install_kubernetes_cli.yml
```

Or include the role in your own playbooks:
```yaml
- hosts: servers
  roles:
    - role: kubernetes_cli
      kubectl_version: "v1.28.0"  # Optional: specify version
```

## Testing

The role has been tested on:
- Ubuntu 20.04 and 22.04
- CentOS/RHEL 7 and 8
- Debian 11

## Future Improvements

- Add support for offline installations
- Add configuration for kubectl context and kubeconfig settings