### PR TITLE
Add Terraform installation to Ansible role

### DIFF
--- a/ansible/roles/install_tools/tasks/main.yml
+++ b/ansible/roles/install_tools/tasks/main.yml
@@ -13,3 +13,20 @@
 
 - name: Install Helm
   command: /tmp/get_helm.sh
+
+- name: Add HashiCorp GPG key
+  apt_key:
+    url: https://apt.releases.hashicorp.com/gpg
+    state: present
+
+- name: Add HashiCorp repository
+  apt_repository:
+    repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    state: present
+    filename: hashicorp
+
+- name: Install Terraform
+  apt:
+    name: terraform
+    state: present
+    update_cache: yes


### PR DESCRIPTION
This PR adds Terraform installation to the existing Ansible role.

Changes include:
- Adding HashiCorp GPG key
- Adding HashiCorp repository
- Installing Terraform package via apt

Terraform is commonly used with other IaC tools like Helm for managing cloud infrastructure and is a valuable addition to the toolset.